### PR TITLE
Add TLS support for raft communication

### DIFF
--- a/candidate.go
+++ b/candidate.go
@@ -54,7 +54,7 @@ func (r *Raft) sendVoteRequests() {
 
 		// Make RPC request in a separate goroutine to prevent blocking operations.
 		go func(n Node) {
-			res := sendRPC(req, n)
+			res := sendRPC(req, n, r.opts.TlsConfig)
 			r.voteCh <- res
 		}(v)
 	}

--- a/follower.go
+++ b/follower.go
@@ -22,7 +22,7 @@ func (r *Raft) runFollowerState() {
 
 			resp := sendRPC(&pb.ApplyRequest{
 				Command: t.log.Cmd,
-			}, n)
+			}, n, r.opts.TlsConfig)
 			if resp.error != nil {
 				r.logger.Printf("Failed to forward apply request to leader: %v", resp.error)
 				t.respond(fmt.Errorf("couldn't apply request: %v", resp.error))

--- a/leader.go
+++ b/leader.go
@@ -136,7 +136,7 @@ func (r *Raft) sendAppendReq(n Node, nextIdx int64, isHeartbeat bool) {
 	}
 	r.mu.Unlock()
 
-	resp := sendRPC(req, n)
+	resp := sendRPC(req, n, r.opts.TlsConfig)
 	r.appendEntryCh <- appendEntryResp{resp, n.ID}
 }
 

--- a/raft.go
+++ b/raft.go
@@ -1,6 +1,7 @@
 package raft
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"github.com/Mathew-Estafanous/raft/pb"
@@ -88,6 +89,10 @@ type Options struct {
 	// LogThreshold represents the total number of log entries that should be reached
 	// before log compaction (snapshot) is triggered. A threshold of 0 means no snapshot creation.
 	LogThreshold uint64
+
+	// TlsConfig when given is used to encrypt communication among raft nodes. TLS is not enabled
+	// if config is left as nil.
+	TlsConfig *tls.Config
 }
 
 // Raft represents a node within the entire raft cluster. It contains the core logic
@@ -176,7 +181,7 @@ func (r *Raft) ListenAndServe(addr string) error {
 // This is a blocking operation and will only return when the raft instance has Shutdown
 // or a fatal error has occurred.
 func (r *Raft) Serve(l net.Listener) error {
-	s := newServer(r, l)
+	s := newServer(r, l, r.opts.TlsConfig)
 	defer s.shutdown()
 	r.logger.Printf("Starting raft on %v", l.Addr().String())
 	go func() {

--- a/rpc.go
+++ b/rpc.go
@@ -2,13 +2,22 @@ package raft
 
 import (
 	"context"
+	"crypto/tls"
 	"github.com/Mathew-Estafanous/raft/pb"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"log"
 )
 
-func sendRPC(req interface{}, target Node) rpcResp {
-	conn, err := grpc.Dial(target.Addr, grpc.WithInsecure())
+func sendRPC(req interface{}, target Node, config *tls.Config) rpcResp {
+	var creds credentials.TransportCredentials
+	if config == nil {
+		creds = insecure.NewCredentials()
+	} else {
+		creds = credentials.NewTLS(config)
+	}
+	conn, err := grpc.NewClient(target.Addr, grpc.WithTransportCredentials(creds))
 	if err != nil {
 		return rpcResp{
 			resp:  nil,

--- a/server.go
+++ b/server.go
@@ -2,8 +2,10 @@ package raft
 
 import (
 	"context"
+	"crypto/tls"
 	"github.com/Mathew-Estafanous/raft/pb"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"net"
 )
 
@@ -19,11 +21,18 @@ type server struct {
 	rpc *grpc.Server
 }
 
-func newServer(raft *Raft, lis net.Listener) *server {
+func newServer(raft *Raft, lis net.Listener, tlsConfig *tls.Config) *server {
+	var rpcServer *grpc.Server
+	if tlsConfig != nil {
+		creds := credentials.NewTLS(tlsConfig)
+		rpcServer = grpc.NewServer(grpc.Creds(creds))
+	} else {
+		rpcServer = grpc.NewServer()
+	}
 	return &server{
 		r:   raft,
 		lis: lis,
-		rpc: grpc.NewServer(),
+		rpc: rpcServer,
 	}
 }
 


### PR DESCRIPTION
### Description of changes

This PR introduces TLS support to enable secure communication in the Raft protocol. This enhancement ensures better confidentiality and integrity during data exchange between nodes. 
