### PR TITLE
Add BBolt-backed persistent storage for raft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# ignore example .data file
+example/.data

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
 	go.etcd.io/bbolt v1.4.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.etcd.io/bbolt v1.4.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.etcd.io/bbolt v1.4.0 h1:TU77id3TnN/zKr7CO/uk+fBCwF2jGcMuw2B/FMAzYIk=
 go.etcd.io/bbolt v1.4.0/go.mod h1:AsD+OCi/qPN1giOX1aiLAha3o1U8rAz65bvN4j0sRuk=
 golang.org/x/net v0.25.0 h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac=

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+go.etcd.io/bbolt v1.4.0 h1:TU77id3TnN/zKr7CO/uk+fBCwF2jGcMuw2B/FMAzYIk=
+go.etcd.io/bbolt v1.4.0/go.mod h1:AsD+OCi/qPN1giOX1aiLAha3o1U8rAz65bvN4j0sRuk=
 golang.org/x/net v0.25.0 h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac=
 golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
 golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=

--- a/storage.go
+++ b/storage.go
@@ -2,8 +2,6 @@ package raft
 
 import (
 	"errors"
-	"fmt"
-	"sync"
 )
 
 var (
@@ -47,106 +45,4 @@ type StableStore interface {
 	// Get returns the value related to that key. An empty slice is returned if
 	// there is no value with that key found.
 	Get(key []byte) ([]byte, error)
-}
-
-// InMemStore is an implementation of the StableStore and LogStore interface.
-// Since it is in-memory, all data is lost on shutdown.
-//
-// NOTE: This implementation is meant for testing and example use-cases and is NOT meant
-// to be used in any production environment. It is up to the client to create the persistence store.
-type InMemStore struct {
-	mu       sync.Mutex
-	logs     []*Log
-	lastIdx  int64
-	lastTerm uint64
-
-	kvMu sync.Mutex
-	kv   map[string][]byte
-}
-
-func NewMemStore() *InMemStore {
-	return &InMemStore{
-		logs:     make([]*Log, 0),
-		lastIdx:  -1,
-		lastTerm: 0,
-		kv:       make(map[string][]byte),
-	}
-}
-
-func (m *InMemStore) LastIndex() int64 {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.lastIdx
-}
-
-func (m *InMemStore) LastTerm() uint64 {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.lastTerm
-}
-
-func (m *InMemStore) GetLog(index int64) (*Log, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.lastIdx < index {
-		return nil, ErrLogNotFound
-	}
-
-	minIdx := m.logs[0].Index
-	if index < minIdx {
-		return m.logs[0], nil
-	}
-	return m.logs[index-minIdx], nil
-}
-
-func (m *InMemStore) AppendLogs(logs []*Log) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.logs = append(m.logs, logs...)
-	m.updateLastLog()
-	return nil
-}
-
-func (m *InMemStore) DeleteRange(min, max int64) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	minIdx := m.logs[0].Index
-	if min < minIdx {
-		return fmt.Errorf("min %v cannot be less than the current minimum index %v", min, minIdx)
-	}
-	min -= minIdx
-	max -= minIdx
-	m.logs = append(m.logs[:min], m.logs[max+1:]...)
-	m.updateLastLog()
-	return nil
-}
-
-func (m *InMemStore) AllLogs() ([]*Log, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	copyLog := make([]*Log, len(m.logs))
-	copy(copyLog, m.logs)
-	return copyLog, nil
-}
-
-func (m *InMemStore) updateLastLog() {
-	if len(m.logs)-1 < 0 {
-		return
-	}
-
-	m.lastIdx = m.logs[len(m.logs)-1].Index
-	m.lastTerm = m.logs[len(m.logs)-1].Term
-}
-
-func (m *InMemStore) Set(key, value []byte) error {
-	m.kvMu.Lock()
-	defer m.kvMu.Unlock()
-	m.kv[string(key)] = value
-	return nil
-}
-
-func (m *InMemStore) Get(key []byte) ([]byte, error) {
-	m.kvMu.Lock()
-	defer m.kvMu.Unlock()
-	return m.kv[string(key)], nil
 }

--- a/store/bbolt.go
+++ b/store/bbolt.go
@@ -1,0 +1,318 @@
+package store
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/Mathew-Estafanous/raft"
+	bolt "go.etcd.io/bbolt"
+)
+
+var (
+	logBucket  = []byte("logs")
+	metaBucket = []byte("meta")
+	kvBucket   = []byte("kv")
+
+	lastIndexKey = []byte("lastIndex")
+	lastTermKey  = []byte("lastTerm")
+)
+
+// BoltStore implements both raft.LogStore and raft.StableStore interfaces
+// using BBolt as the underlying storage engine
+type BoltStore struct {
+	db        *bolt.DB
+	mu        sync.RWMutex
+	lastIndex int64
+	lastTerm  uint64
+}
+
+// NewBoltStore creates a new store persisted at the given path
+func NewBoltStore(path string) (*BoltStore, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return nil, err
+	}
+
+	db, err := bolt.Open(path, 0600, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucketIfNotExists(logBucket); err != nil {
+			return err
+		}
+		if _, err := tx.CreateBucketIfNotExists(metaBucket); err != nil {
+			return err
+		}
+		if _, err := tx.CreateBucketIfNotExists(kvBucket); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create buckets: %w", err)
+	}
+
+	store := &BoltStore{
+		db:        db,
+		lastIndex: -1,
+		lastTerm:  0,
+	}
+
+	err = db.View(func(tx *bolt.Tx) error {
+		metaBkt := tx.Bucket(metaBucket)
+
+		lastIdxBytes := metaBkt.Get(lastIndexKey)
+		if lastIdxBytes != nil {
+			store.lastIndex = int64(binary.BigEndian.Uint64(lastIdxBytes))
+		}
+
+		lastTermBytes := metaBkt.Get(lastTermKey)
+		if lastTermBytes != nil {
+			store.lastTerm = binary.BigEndian.Uint64(lastTermBytes)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return store, nil
+}
+
+// Close closes the underlying BBolt database
+func (b *BoltStore) Close() error {
+	return b.db.Close()
+}
+
+// Delete will completely erase all data in the database
+func (b *BoltStore) Delete() error {
+	return b.db.Update(func(tx *bolt.Tx) error {
+		if err := tx.DeleteBucket(logBucket); err != nil {
+			return err
+		}
+		if err := tx.DeleteBucket(metaBucket); err != nil {
+			return err
+		}
+		if err := tx.DeleteBucket(kvBucket); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+// LastIndex returns the last index in the log
+func (b *BoltStore) LastIndex() int64 {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.lastIndex
+}
+
+// LastTerm returns the term of the last log entry
+func (b *BoltStore) LastTerm() uint64 {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.lastTerm
+}
+
+// GetLog retrieves a log entry at a specific index
+func (b *BoltStore) GetLog(index int64) (*raft.Log, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	var log *raft.Log
+	err := b.db.View(func(tx *bolt.Tx) error {
+		logBkt := tx.Bucket(logBucket)
+
+		if b.lastIndex < index {
+			return raft.ErrLogNotFound
+		}
+
+		c := logBkt.Cursor()
+		k, _ := c.First()
+		if k == nil {
+			return raft.ErrLogNotFound
+		}
+
+		minIdx := int64(binary.BigEndian.Uint64(k))
+
+		if index < minIdx {
+			data := logBkt.Get(k)
+			if data == nil {
+				return raft.ErrLogNotFound
+			}
+
+			log = &raft.Log{}
+			return json.Unmarshal(data, log)
+		}
+
+		key := make([]byte, 8)
+		binary.BigEndian.PutUint64(key, uint64(index))
+		data := logBkt.Get(key)
+		if data == nil {
+			return raft.ErrLogNotFound
+		}
+
+		log = &raft.Log{}
+		return json.Unmarshal(data, log)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return log, nil
+}
+
+// AllLogs retrieves all log entries
+func (b *BoltStore) AllLogs() ([]*raft.Log, error) {
+	var logs []*raft.Log
+	err := b.db.View(func(tx *bolt.Tx) error {
+		logBkt := tx.Bucket(logBucket)
+
+		return logBkt.ForEach(func(k, v []byte) error {
+			log := &raft.Log{}
+			if err := json.Unmarshal(v, log); err != nil {
+				return err
+			}
+			logs = append(logs, log)
+			return nil
+		})
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return logs, nil
+}
+
+// AppendLogs adds new log entries
+func (b *BoltStore) AppendLogs(logs []*raft.Log) error {
+	if len(logs) == 0 {
+		return nil
+	}
+
+	err := b.db.Update(func(tx *bolt.Tx) error {
+		logBkt := tx.Bucket(logBucket)
+		metaBkt := tx.Bucket(metaBucket)
+
+		for _, log := range logs {
+			data, err := json.Marshal(log)
+			if err != nil {
+				return err
+			}
+
+			key := make([]byte, 8)
+			binary.BigEndian.PutUint64(key, uint64(log.Index))
+
+			if err := logBkt.Put(key, data); err != nil {
+				return err
+			}
+
+			if log.Index > b.lastIndex {
+				b.mu.Lock()
+				b.lastIndex = log.Index
+				b.lastTerm = log.Term
+				b.mu.Unlock()
+
+				idxKey := make([]byte, 8)
+				binary.BigEndian.PutUint64(idxKey, uint64(b.lastIndex))
+				if err := metaBkt.Put(lastIndexKey, idxKey); err != nil {
+					return err
+				}
+
+				termKey := make([]byte, 8)
+				binary.BigEndian.PutUint64(termKey, b.lastTerm)
+				if err := metaBkt.Put(lastTermKey, termKey); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+	return err
+}
+
+// DeleteRange removes log entries in the specified range
+func (b *BoltStore) DeleteRange(min, max int64) error {
+	err := b.db.Update(func(tx *bolt.Tx) error {
+		logBkt := tx.Bucket(logBucket)
+
+		c := logBkt.Cursor()
+		k, _ := c.First()
+		if k == nil {
+			return fmt.Errorf("no logs found")
+		}
+
+		minIdx := int64(binary.BigEndian.Uint64(k))
+		if min < minIdx {
+			return fmt.Errorf("min %v cannot be less than the current minimum index %v", min, minIdx)
+		}
+
+		for i := min; i <= max; i++ {
+			key := make([]byte, 8)
+			binary.BigEndian.PutUint64(key, uint64(i))
+			if err := logBkt.Delete(key); err != nil {
+				return err
+			}
+		}
+
+		if max >= b.lastIndex {
+			k, v := c.Last()
+			b.mu.Lock()
+			if k == nil {
+				b.lastIndex = -1
+				b.lastTerm = 0
+			} else {
+				b.lastIndex = int64(binary.BigEndian.Uint64(k))
+				log := &raft.Log{}
+				if err := json.Unmarshal(v, log); err != nil {
+					b.mu.Unlock()
+					return err
+				}
+				b.lastTerm = log.Term
+			}
+			b.mu.Unlock()
+			metaBkt := tx.Bucket(metaBucket)
+
+			idxKey := make([]byte, 8)
+			binary.BigEndian.PutUint64(idxKey, uint64(b.lastIndex))
+			if err := metaBkt.Put(lastIndexKey, idxKey); err != nil {
+				return err
+			}
+
+			termKey := make([]byte, 8)
+			binary.BigEndian.PutUint64(termKey, b.lastTerm)
+			if err := metaBkt.Put(lastTermKey, termKey); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	return err
+}
+
+// Set stores a key-value pair in the stable store
+func (b *BoltStore) Set(key, value []byte) error {
+	return b.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket(kvBucket).Put(key, value)
+	})
+}
+
+// Get retrieves a value by key from the stable store
+func (b *BoltStore) Get(key []byte) ([]byte, error) {
+	var value []byte
+	err := b.db.View(func(tx *bolt.Tx) error {
+		val := tx.Bucket(kvBucket).Get(key)
+		if val != nil {
+			value = append([]byte{}, val...)
+		}
+		return nil
+	})
+	return value, err
+}

--- a/store/bbolt_test.go
+++ b/store/bbolt_test.go
@@ -1,0 +1,515 @@
+package store
+
+import (
+	bolt "go.etcd.io/bbolt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Mathew-Estafanous/raft"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupBoltStore creates a temporary BoltStore for testing
+func setupBoltStore(t *testing.T) (*BoltStore, string) {
+	t.Helper()
+	tempDir, err := os.MkdirTemp("", "boltstore-test-*")
+	require.NoError(t, err, "Failed to create temp directory")
+
+	dbPath := filepath.Join(tempDir, "test.db")
+
+	store, err := NewBoltStore(dbPath)
+	require.NoError(t, err, "Failed to create BoltStore")
+
+	return store, tempDir
+}
+
+// cleanupBoltStore closes the BoltStore and removes the temporary directory
+func cleanupBoltStore(t *testing.T, store *BoltStore, tempDir string) {
+	t.Helper()
+	err := store.Close()
+	require.NoError(t, err, "Failed to close BoltStore")
+
+	err = os.RemoveAll(tempDir)
+	require.NoError(t, err, "Failed to remove temp directory")
+}
+
+func TestNewBoltStore(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "boltstore-test-*")
+	require.NoError(t, err, "Failed to create temp directory")
+	defer func() {
+		err = os.RemoveAll(tempDir)
+		assert.NoError(t, err)
+	}()
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{
+			name:    "Valid path",
+			path:    filepath.Join(tempDir, "valid.db"),
+			wantErr: false,
+		},
+		{
+			name:    "Invalid path",
+			path:    filepath.Join("/nonexistent", "invalid.db"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, err := NewBoltStore(tt.path)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, store)
+			assert.Equal(t, int64(-1), store.lastIndex)
+			assert.Equal(t, uint64(0), store.lastTerm)
+
+			if store != nil {
+				err = store.Close()
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestBoltStore_Close(t *testing.T) {
+	store, tempDir := setupBoltStore(t)
+	defer func() {
+		err := os.RemoveAll(tempDir)
+		assert.NoError(t, err)
+	}()
+
+	err := store.Close()
+	assert.NoError(t, err)
+
+	_, err = store.Get([]byte("key"))
+	assert.Error(t, err)
+}
+
+func TestBoltStore_Delete(t *testing.T) {
+	store, tempDir := setupBoltStore(t)
+	defer cleanupBoltStore(t, store, tempDir)
+
+	err := store.Set([]byte("key"), []byte("value"))
+	require.NoError(t, err)
+
+	err = store.Delete()
+	assert.NoError(t, err)
+
+	err = store.db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucketIfNotExists(logBucket); err != nil {
+			return err
+		}
+		if _, err := tx.CreateBucketIfNotExists(metaBucket); err != nil {
+			return err
+		}
+		if _, err := tx.CreateBucketIfNotExists(kvBucket); err != nil {
+			return err
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	value, err := store.Get([]byte("key"))
+	assert.NoError(t, err)
+	assert.Nil(t, value)
+}
+
+func TestBoltStore_LastIndex_LastTerm(t *testing.T) {
+	store, tempDir := setupBoltStore(t)
+	defer cleanupBoltStore(t, store, tempDir)
+
+	// Initially, lastIndex should be -1 and lastTerm should be 0
+	assert.Equal(t, int64(-1), store.LastIndex())
+	assert.Equal(t, uint64(0), store.LastTerm())
+
+	logs := []*raft.Log{
+		{
+			Type:  raft.Entry,
+			Index: 1,
+			Term:  1,
+			Cmd:   []byte("command1"),
+		},
+		{
+			Type:  raft.Entry,
+			Index: 2,
+			Term:  1,
+			Cmd:   []byte("command2"),
+		},
+		{
+			Type:  raft.Entry,
+			Index: 3,
+			Term:  2,
+			Cmd:   []byte("command3"),
+		},
+	}
+	err := store.AppendLogs(logs)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(3), store.LastIndex())
+	assert.Equal(t, uint64(2), store.LastTerm())
+}
+
+func TestBoltStore_GetLog(t *testing.T) {
+	store, tempDir := setupBoltStore(t)
+	defer cleanupBoltStore(t, store, tempDir)
+
+	logs := []*raft.Log{
+		{
+			Type:  raft.Entry,
+			Index: 1,
+			Term:  1,
+			Cmd:   []byte("command1"),
+		},
+		{
+			Type:  raft.Entry,
+			Index: 2,
+			Term:  1,
+			Cmd:   []byte("command2"),
+		},
+		{
+			Type:  raft.Entry,
+			Index: 3,
+			Term:  2,
+			Cmd:   []byte("command3"),
+		},
+	}
+	err := store.AppendLogs(logs)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		index     int64
+		wantLog   *raft.Log
+		wantError error
+	}{
+		{
+			name:      "Get existing log",
+			index:     2,
+			wantLog:   logs[1],
+			wantError: nil,
+		},
+		{
+			name:      "Get first log",
+			index:     1,
+			wantLog:   logs[0],
+			wantError: nil,
+		},
+		{
+			name:      "Get last log",
+			index:     3,
+			wantLog:   logs[2],
+			wantError: nil,
+		},
+		{
+			name:      "Index too high",
+			index:     4,
+			wantLog:   nil,
+			wantError: raft.ErrLogNotFound,
+		},
+		{
+			name:      "Index too low",
+			index:     0,
+			wantLog:   logs[0],
+			wantError: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log, err := store.GetLog(tt.index)
+			if tt.wantError != nil {
+				assert.Equal(t, tt.wantError, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantLog.Type, log.Type)
+			assert.Equal(t, tt.wantLog.Index, log.Index)
+			assert.Equal(t, tt.wantLog.Term, log.Term)
+			assert.Equal(t, tt.wantLog.Cmd, log.Cmd)
+		})
+	}
+}
+
+func TestBoltStore_AllLogs(t *testing.T) {
+	store, tempDir := setupBoltStore(t)
+	defer cleanupBoltStore(t, store, tempDir)
+
+	// Test with empty store
+	logs, err := store.AllLogs()
+	assert.NoError(t, err)
+	assert.Empty(t, logs)
+
+	// Add some logs
+	inputLogs := []*raft.Log{
+		{
+			Type:  raft.Entry,
+			Index: 1,
+			Term:  1,
+			Cmd:   []byte("command1"),
+		},
+		{
+			Type:  raft.Entry,
+			Index: 2,
+			Term:  1,
+			Cmd:   []byte("command2"),
+		},
+		{
+			Type:  raft.Entry,
+			Index: 3,
+			Term:  2,
+			Cmd:   []byte("command3"),
+		},
+	}
+	err = store.AppendLogs(inputLogs)
+	require.NoError(t, err)
+
+	logs, err = store.AllLogs()
+	assert.NoError(t, err)
+	assert.Len(t, logs, 3)
+
+	for i, log := range logs {
+		assert.Equal(t, inputLogs[i].Type, log.Type)
+		assert.Equal(t, inputLogs[i].Index, log.Index)
+		assert.Equal(t, inputLogs[i].Term, log.Term)
+		assert.Equal(t, inputLogs[i].Cmd, log.Cmd)
+	}
+}
+
+func TestBoltStore_AppendLogs(t *testing.T) {
+	store, tempDir := setupBoltStore(t)
+	defer cleanupBoltStore(t, store, tempDir)
+
+	// Test with empty logs slice
+	err := store.AppendLogs([]*raft.Log{})
+	assert.NoError(t, err)
+
+	logs1 := []*raft.Log{
+		{
+			Type:  raft.Entry,
+			Index: 1,
+			Term:  1,
+			Cmd:   []byte("command1"),
+		},
+		{
+			Type:  raft.Entry,
+			Index: 2,
+			Term:  1,
+			Cmd:   []byte("command2"),
+		},
+	}
+	err = store.AppendLogs(logs1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), store.LastIndex())
+	assert.Equal(t, uint64(1), store.LastTerm())
+
+	logs2 := []*raft.Log{
+		{
+			Type:  raft.Entry,
+			Index: 3,
+			Term:  2,
+			Cmd:   []byte("command3"),
+		},
+		{
+			Type:  raft.Entry,
+			Index: 4,
+			Term:  2,
+			Cmd:   []byte("command4"),
+		},
+	}
+	err = store.AppendLogs(logs2)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(4), store.LastIndex())
+	assert.Equal(t, uint64(2), store.LastTerm())
+
+	allLogs, err := store.AllLogs()
+	assert.NoError(t, err)
+	assert.Len(t, allLogs, 4)
+}
+
+func TestBoltStore_DeleteRange(t *testing.T) {
+	logs := []*raft.Log{
+		{
+			Type:  raft.Entry,
+			Index: 1,
+			Term:  1,
+			Cmd:   []byte("command1"),
+		},
+		{
+			Type:  raft.Entry,
+			Index: 2,
+			Term:  1,
+			Cmd:   []byte("command2"),
+		},
+		{
+			Type:  raft.Entry,
+			Index: 3,
+			Term:  2,
+			Cmd:   []byte("command3"),
+		},
+		{
+			Type:  raft.Entry,
+			Index: 4,
+			Term:  2,
+			Cmd:   []byte("command4"),
+		},
+		{
+			Type:  raft.Entry,
+			Index: 5,
+			Term:  3,
+			Cmd:   []byte("command5"),
+		},
+	}
+
+	tests := []struct {
+		name          string
+		min           int64
+		max           int64
+		wantErr       bool
+		wantLastIndex int64
+		wantLastTerm  uint64
+		wantLogCount  int
+	}{
+		{
+			name:          "Delete middle range",
+			min:           2,
+			max:           3,
+			wantErr:       false,
+			wantLastIndex: 5,
+			wantLastTerm:  3,
+			wantLogCount:  3,
+		},
+		{
+			name:          "Delete to the end",
+			min:           4,
+			max:           5,
+			wantErr:       false,
+			wantLastIndex: 3,
+			wantLastTerm:  2,
+			wantLogCount:  3,
+		},
+		{
+			name:          "Delete all logs",
+			min:           1,
+			max:           5,
+			wantErr:       false,
+			wantLastIndex: -1,
+			wantLastTerm:  0,
+			wantLogCount:  0,
+		},
+		{
+			name:          "Deletes up to max even if max > lastIndex",
+			min:           4,
+			max:           6,
+			wantErr:       false,
+			wantLastIndex: 3,
+			wantLastTerm:  2,
+			wantLogCount:  3,
+		},
+		{
+			name:          "Invalid range (min < existing min)",
+			min:           0,
+			max:           1,
+			wantErr:       true,
+			wantLastIndex: -1,
+			wantLastTerm:  0,
+			wantLogCount:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, tempDir := setupBoltStore(t)
+			defer cleanupBoltStore(t, store, tempDir)
+
+			err := store.AppendLogs(logs)
+			require.NoError(t, err)
+
+			err = store.DeleteRange(tt.min, tt.max)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			// Verify lastIndex and lastTerm
+			assert.Equal(t, tt.wantLastIndex, store.LastIndex())
+			assert.Equal(t, tt.wantLastTerm, store.LastTerm())
+
+			// Verify log count
+			allLogs, err := store.AllLogs()
+			assert.NoError(t, err)
+			assert.Len(t, allLogs, tt.wantLogCount)
+		})
+	}
+}
+
+func TestBoltStore_Set_Get(t *testing.T) {
+	store, tempDir := setupBoltStore(t)
+	defer cleanupBoltStore(t, store, tempDir)
+
+	tests := []struct {
+		name  string
+		key   []byte
+		value []byte
+	}{
+		{
+			name:  "Simple key-value",
+			key:   []byte("key1"),
+			value: []byte("value1"),
+		},
+		{
+			name:  "Empty value",
+			key:   []byte("key2"),
+			value: []byte{},
+		},
+		{
+			name:  "Binary data",
+			key:   []byte{0x00, 0x01, 0x02},
+			value: []byte{0x03, 0x04, 0x05},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set the key-value pair
+			err := store.Set(tt.key, tt.value)
+			assert.NoError(t, err)
+
+			// Get the value
+			value, err := store.Get(tt.key)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.value, value)
+		})
+	}
+
+	t.Run("Non-existent key", func(t *testing.T) {
+		value, err := store.Get([]byte("nonexistent"))
+		assert.NoError(t, err)
+		assert.Nil(t, value)
+	})
+
+	t.Run("Overwrite key", func(t *testing.T) {
+		key := []byte("overwrite")
+		value1 := []byte("value1")
+		value2 := []byte("value2")
+
+		err := store.Set(key, value1)
+		assert.NoError(t, err)
+
+		err = store.Set(key, value2)
+		assert.NoError(t, err)
+
+		value, err := store.Get(key)
+		assert.NoError(t, err)
+		assert.Equal(t, value2, value)
+	})
+}

--- a/store/memory.go
+++ b/store/memory.go
@@ -1,0 +1,109 @@
+package store
+
+import (
+	"fmt"
+	"github.com/Mathew-Estafanous/raft"
+	"sync"
+)
+
+// InMemStore is an implementation of the StableStore and LogStore interface.
+// Since it is in-memory, all data is lost on shutdown.
+//
+// NOTE: This implementation is meant for testing and example use-cases and is NOT meant
+// to be used in any production environment. It is up to the client to create the persistence store.
+type InMemStore struct {
+	mu       sync.Mutex
+	logs     []*raft.Log
+	lastIdx  int64
+	lastTerm uint64
+
+	kvMu sync.Mutex
+	kv   map[string][]byte
+}
+
+func NewMemStore() *InMemStore {
+	return &InMemStore{
+		logs:     make([]*raft.Log, 0),
+		lastIdx:  -1,
+		lastTerm: 0,
+		kv:       make(map[string][]byte),
+	}
+}
+
+func (m *InMemStore) LastIndex() int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastIdx
+}
+
+func (m *InMemStore) LastTerm() uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastTerm
+}
+
+func (m *InMemStore) GetLog(index int64) (*raft.Log, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.lastIdx < index {
+		return nil, raft.ErrLogNotFound
+	}
+
+	minIdx := m.logs[0].Index
+	if index < minIdx {
+		return m.logs[0], nil
+	}
+	return m.logs[index-minIdx], nil
+}
+
+func (m *InMemStore) AppendLogs(logs []*raft.Log) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.logs = append(m.logs, logs...)
+	m.updateLastLog()
+	return nil
+}
+
+func (m *InMemStore) DeleteRange(min, max int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	minIdx := m.logs[0].Index
+	if min < minIdx {
+		return fmt.Errorf("min %v cannot be less than the current minimum index %v", min, minIdx)
+	}
+	min -= minIdx
+	max -= minIdx
+	m.logs = append(m.logs[:min], m.logs[max+1:]...)
+	m.updateLastLog()
+	return nil
+}
+
+func (m *InMemStore) AllLogs() ([]*raft.Log, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	copyLog := make([]*raft.Log, len(m.logs))
+	copy(copyLog, m.logs)
+	return copyLog, nil
+}
+
+func (m *InMemStore) updateLastLog() {
+	if len(m.logs)-1 < 0 {
+		return
+	}
+
+	m.lastIdx = m.logs[len(m.logs)-1].Index
+	m.lastTerm = m.logs[len(m.logs)-1].Term
+}
+
+func (m *InMemStore) Set(key, value []byte) error {
+	m.kvMu.Lock()
+	defer m.kvMu.Unlock()
+	m.kv[string(key)] = value
+	return nil
+}
+
+func (m *InMemStore) Get(key []byte) ([]byte, error) {
+	m.kvMu.Lock()
+	defer m.kvMu.Unlock()
+	return m.kv[string(key)], nil
+}


### PR DESCRIPTION
### Summary  
Replaced the in-memory storage with a BBolt-based `BoltStore` to enable persistent raft storage. Refactored associated logic and updated examples. The in-memory implementation was retained for testing and demonstration purposes.  

### Changes  
- Integrated BBolt-based persistent storage (`BoltStore`) for raft.  
- Updated examples to utilize the new persistent storage.  
- Refactored logic to support the new storage backend.  
- Preserved in-memory store for test/example purposes.